### PR TITLE
Use implementation instead

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,6 +17,6 @@ android {
 
 dependencies {
     //noinspection GradleDynamicVersion
-    provided 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
     compile "com.tonyodev.fetch2:fetch2:2.0.0-RC12"
 }


### PR DESCRIPTION
To work with more recent versions of gradle/react-native.
I could not build the android project in react-native 0.58.5 without updating this.