### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ In your `AppDelegate.m` add the following code:
 
 ...
 
-- (void)application:(UIApplication *)application handleEventsForBackgroundURLSession:(NSString *)identifier completionHandler:(void (^)())completionHandler
+- (void)application:(UIApplication *)application handleEventsForBackgroundURLSession:(NSString *)identifier completionHandler:(void (^)(void))completionHandler
 {
   [RNBackgroundDownloader setCompletionHandlerWithIdentifier:identifier completionHandler:completionHandler];
 }


### PR DESCRIPTION
Fix based on Xcode 10.2.1 warning and Xcode fix suggestion:
"Conflicting parameter types in implementation of 'application:handleEventsForBackgroundURLSession:completionHandler:': 'void (^ _Nonnull __strong)(void)' vs 'void (^__strong _Nonnull)()'
This block declaration is not a prototype
Insert 'void'"