### PR TITLE
Autolink support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ The real challenge of using this method is making sure the app's UI is always up
 For **`RN <= 0.57.0`** use `$ yarn add react-native-background-downloader@1.1.0`
 
 ### Mostly automatic installation
+Any React Native version **`>= 0.60`** supports autolinking so nothing should be done.
+
+For anything **`< 0.60`** run the following link command
 
 `$ react-native link react-native-background-downloader`
 

--- a/react-native-background-downloader.podspec
+++ b/react-native-background-downloader.podspec
@@ -1,14 +1,13 @@
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name         = 'react-native-background-downloader'
-  s.version      = '1.0.0'
+  s.name         = package['name']
+  s.version      = package['version']
   s.summary      = 'React Native background downloader'
-  s.description  = <<-DESC
-  A library for React-Native to help you download large files on iOS and Android both in the foreground and most importantly in the background.
-                   DESC
-  s.author       = 'elad@helleko.com'
-  s.homepage     = 'https://github.com/EkoLabs/react-native-background-downloader'
-  s.license      = 'MIT'
+  s.description  = package['description']
+  s.author       = package['author']
+  s.homepage     = package['repository']['url']
+  s.license      = package['license']
   s.platform     = :ios, '7.0'
   s.source       = { git: 'https://github.com/EkoLabs/react-native-background-downloader.git', tag: 'master' }
   s.source_files = 'ios/**/*.{h,m}'

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      ios: {
+        project: "./ios/RNBackgroundDownloader.xcodeproj"
+      },
+      android: {
+        sourceDir: "./android"
+      }
+    }
+  }
+};


### PR DESCRIPTION
Adds support for [autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) which was introduced in RN 0.60.