### PR TITLE
Fix #60: Crash on Android when onCompleted is called after Fetch instance is closed

### DIFF
--- a/android/src/main/java/com/eko/RNBackgroundDownloaderModule.java
+++ b/android/src/main/java/com/eko/RNBackgroundDownloaderModule.java
@@ -317,7 +317,7 @@ public class RNBackgroundDownloaderModule extends ReactContextBaseJavaModule imp
       }
     }
   }
-  
+
   @Override
   public void onProgress(Download download, long l, long l1) {
     synchronized(sharedLock) {

--- a/android/src/main/java/com/eko/RNBackgroundDownloaderModule.java
+++ b/android/src/main/java/com/eko/RNBackgroundDownloaderModule.java
@@ -312,10 +312,12 @@ public class RNBackgroundDownloaderModule extends ReactContextBaseJavaModule imp
       }
 
       removeFromMaps(download.getId());
-      fetch.remove(download.getId());
+      if (!fetch.isClosed()) {
+        fetch.remove(download.getId());
+      }
     }
   }
-
+  
   @Override
   public void onProgress(Download download, long l, long l1) {
     synchronized(sharedLock) {

--- a/ios/RNBackgroundDownloader.m
+++ b/ios/RNBackgroundDownloader.m
@@ -255,8 +255,6 @@ RCT_EXPORT_METHOD(checkForExistingDownloads: (RCTPromiseResolveBlock)resolve rej
                 lastProgressReport = now;
                 [progressReports removeAllObjects];
             }
-            lastProgressReport = now;
-            [progressReports removeAllObjects];
         }
     }
 }


### PR DESCRIPTION
This PR fixes #60 which is a crash which happens when download is interrupted by exiting the app on Android and the Fetch instance is already closed by the time the onComplete callback is called.