### PR TITLE
Parallel download in Android & Last progress date fix

### DIFF
--- a/android/src/main/java/com/eko/RNBackgroundDownloaderModule.java
+++ b/android/src/main/java/com/eko/RNBackgroundDownloaderModule.java
@@ -24,6 +24,8 @@ import com.tonyodev.fetch2.Request;
 import com.tonyodev.fetch2.Status;
 import com.tonyodev.fetch2core.DownloadBlock;
 import com.tonyodev.fetch2core.Func;
+import com.tonyodev.fetch2.HttpUrlConnectionDownloader;
+import com.tonyodev.fetch2core.Downloader;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -81,6 +83,8 @@ public class RNBackgroundDownloaderModule extends ReactContextBaseJavaModule imp
     FetchConfiguration fetchConfiguration = new FetchConfiguration.Builder(this.getReactApplicationContext())
             .setDownloadConcurrentLimit(4)
             .setNamespace("RNBackgroundDownloader")
+            .enableRetryOnNetworkGain(true)
+            .setHttpDownloader(new HttpUrlConnectionDownloader(Downloader.FileDownloaderType.PARALLEL))
             .build();
     fetch = Fetch.Impl.getInstance(fetchConfiguration);
     fetch.addListener(this);

--- a/android/src/main/java/com/eko/RNBackgroundDownloaderModule.java
+++ b/android/src/main/java/com/eko/RNBackgroundDownloaderModule.java
@@ -236,6 +236,7 @@ public class RNBackgroundDownloaderModule extends ReactContextBaseJavaModule imp
     );
 
     synchronized(sharedLock) {
+      lastProgressReport = new Date();
       idToRequestId.put(id, request.getId());
       requestIdToConfig.put(request.getId(), config);
       saveConfigMap();

--- a/ios/RNBackgroundDownloader.m
+++ b/ios/RNBackgroundDownloader.m
@@ -65,6 +65,7 @@ RCT_EXPORT_MODULE();
         NSString *bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
         NSString *sessonIdentifier = [bundleIdentifier stringByAppendingString:@".backgrounddownloadtask"];
         sessionConfig = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:sessonIdentifier];
+        sessionConfig.HTTPMaximumConnectionsPerHost = 4;
         progressReports = [[NSMutableDictionary alloc] init];
         lastProgressReport = [[NSDate alloc] init];
         sharedLock = [NSNumber numberWithInt:1];

--- a/ios/RNBackgroundDownloader.m
+++ b/ios/RNBackgroundDownloader.m
@@ -137,6 +137,7 @@ RCT_EXPORT_METHOD(download: (NSDictionary *) options) {
         idToPercentMap[identifier] = @0.0;
         
         [task resume];
+        lastProgressReport = [[NSDate alloc] init];
     }
 }
 


### PR DESCRIPTION
- Enable parallel download in Android by using custom HttpUrlConnectionDownloader
- Reset last progress report date when starting download, which was set in initialisation only before