### PR TITLE
Keep the listeners from the original tasks when checkForExistingDownloads is called

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ export function checkForExistingDownloads() {
     return RNBackgroundDownloader.checkForExistingDownloads()
         .then(foundTasks => {
             return foundTasks.map(taskInfo => {
-                let task = new DownloadTask(taskInfo);
+                let task = new DownloadTask(taskInfo,tasksMap.get(taskInfo.id));
                 if (taskInfo.state === RNBackgroundDownloader.TaskRunning) {
                     task.state = 'DOWNLOADING';
                 } else if (taskInfo.state === RNBackgroundDownloader.TaskSuspended) {

--- a/lib/downloadTask.js
+++ b/lib/downloadTask.js
@@ -12,7 +12,7 @@ export default class DownloadTask {
     bytesWritten = 0
     totalBytes = 0
 
-    constructor(taskInfo) {
+    constructor(taskInfo, originalTask) {
         if (typeof taskInfo === 'string') {
             this.id = taskInfo;
         } else {
@@ -20,6 +20,12 @@ export default class DownloadTask {
             this.percent = taskInfo.percent;
             this.bytesWritten = taskInfo.bytesWritten;
             this.totalBytes = taskInfo.totalBytes;
+        }
+        if(originalTask){
+            this._beginHandler= originalTask._beginHandler
+            this._progressHandler= originalTask._progressHandler
+            this._doneHandler= originalTask._doneHandler
+            this._errorHandler= originalTask._errorHandler
         }
     }
 


### PR DESCRIPTION
First of all, this is definitely not a bug fix, just a suggestion :)

I know that the `checkForExistingDownloads` call is intended to only re-attach the lost downloads after the app is restarted somehow. But with this PR it could be easily extended to be able to control the currently running tasks without the need to keep all the task references in the application code. And still, you don't need to re-subscribe for the events after the tasks are resumed.

In our use case, we started a download for a lot of files in parallel and recently added the feature for pausing the whole process. A solution would have been to track all the tasks ourselves and control those, but we realized that the tasks already in a map on the native side and also in another map on the JS side. By adding these couple extra lines we were able to keep the original listeners on the tasks (so we could monitor the progress) and retrieve the running tasks anytime without keeping track of them in our code.

Let me know what do think.