### PR TITLE
fix: Move iOS session init at download start into the synchronised block to avoid using invalidated session

### DIFF
--- a/ios/RNBackgroundDownloader.m
+++ b/ios/RNBackgroundDownloader.m
@@ -116,7 +116,6 @@ RCT_EXPORT_METHOD(download: (NSDictionary *) options) {
         NSLog(@"[RNBackgroundDownloader] - [Error] id, url and destination must be set");
         return;
     }
-    [self lazyInitSession];
     
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:url]];
     if (headers != nil) {
@@ -126,6 +125,7 @@ RCT_EXPORT_METHOD(download: (NSDictionary *) options) {
     }
     
     @synchronized (sharedLock) {
+        [self lazyInitSession];
         NSURLSessionDownloadTask __strong *task = [urlSession downloadTaskWithRequest:request];
         RNBGDTaskConfig *taskConfig = [[RNBGDTaskConfig alloc] initWithDictionary: @{@"id": identifier, @"destination": destination}];
 


### PR DESCRIPTION
Hi!

We had a couple of crash reports with this error: 
> SIGABRT: Task created in a session that has been invalidated

After a bit of investigation, we found that a potential cause of the issue (although it's really hard to reproduce) is that at the download start the initialization of the session is outside of the synchronized block, which could lead to that it could get a session that's invalidated in the meantime because of concurrently finishing tasks. This matches what we saw in the logs as our users started a lot of concurrent downloads, they canceled the tasks (this is an asynchronous action), and soon after that (in a minute) they started again a bunch of tasks. If the cancels just finished when the new downloads are started this could lead to the situation of getting an invalidated session.

We tested this solution and looks working but it's not yet in production and as I mentioned as we cannot reproduce the original crash, so it's not 100% that this PR fixed the issue, but we still think that this could be at least a fix for some cases.

Let me know what do you think.